### PR TITLE
if no args provided, automatically call `start --all`

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -17,4 +17,8 @@ else
     ARGS="--config=$CONFIGDIR/ngrok.yml $ARGS"
 fi
 
+if [ $# -eq 0 ]; then
+    ARGS="start $ARGS --all"
+fi
+
 exec ngrok "$@" $ARGS


### PR DESCRIPTION
closes #3