### PR TITLE
Unpack agent release

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -10,7 +10,7 @@ let
       version = version;
       src = fetchurl { inherit sha256 url; };
       sourceRoot = ".";
-      unpackPhase = "cp $src ngrok";
+      unpackPhase = "${pkgs.unzip}/bin/unzip $src ngrok";
       buildPhase = "chmod a+x ngrok";
       installPhase = ''
         install -D ngrok $out/bin/ngrok


### PR DESCRIPTION
The previous release code produced a 'release.json' that contained raw
binaries rather than zip archives containing the agent.

Changing those binaries to zip archives doesn't exactly work, leading to
errors like:

```
exec: ngrok: Exec format error
```

This adds an unpack phase to give us the appropriate format.

Now, a natural question to ask is "why not use fetchTarball instead of
fetchurl, it unzips files for you?"

The answer to that is that our release.json is generated with the sha of
the zip file, but fetchTarball needs the unpacked sha of the directory
tree (nix-prefetch-url --unpack).

Internally, we _can_ derive that, but it's currently easier to use the
sha of the artifact we download directly, partly because other release
mechanisms (brew, etc) expect the zip's sha too.

I also don't think there's any significant difference between the two
options.

We'll have to re-run the release job to actually pick up this change,
but this should let it build and push correct docker images.